### PR TITLE
build with wasm-pack instead

### DIFF
--- a/evergreen.yml
+++ b/evergreen.yml
@@ -168,21 +168,20 @@ functions:
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           wasm-pack build schema-builder-library \
             --release \
-            --target nodejs \
             --no-default-features \
             --features wasm
           wasm-pack pack schema-builder-library
           # normalize the tgz filename so the s3 path is stable across version bumps
           mv schema-builder-library/pkg/schema-builder-library-*.tgz \
-             schema-builder-library/pkg/schema-builder-library-nodejs.tgz
+             schema-builder-library/pkg/schema-builder-library.tgz
 
   "upload schema-builder-library wasm":
     - *assume_role_cmd
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/schema-builder-library/pkg/schema-builder-library-nodejs.tgz
-        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema-builder-library-nodejs.tgz
+        local_file: mongosql-rs/schema-builder-library/pkg/schema-builder-library.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema-builder-library.tgz
         permissions: public-read
         content_type: application/gzip
 

--- a/evergreen.yml
+++ b/evergreen.yml
@@ -165,23 +165,26 @@ functions:
         working_dir: mongosql-rs
         script: |
           ${prepare_shell}
-          rustup target add wasm32-unknown-unknown
-          cargo build \
-            --target wasm32-unknown-unknown \
-            --package schema-builder-library \
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          wasm-pack build schema-builder-library \
             --release \
+            --target nodejs \
             --no-default-features \
-            --features=wasm
+            --features wasm
+          wasm-pack pack schema-builder-library
+          # normalize the tgz filename so the s3 path is stable across version bumps
+          mv schema-builder-library/pkg/schema-builder-library-*.tgz \
+             schema-builder-library/pkg/schema-builder-library-nodejs.tgz
 
   "upload schema-builder-library wasm":
     - *assume_role_cmd
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/target/wasm32-unknown-unknown/release/schema_builder_library.wasm
-        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema_builder_library.wasm
+        local_file: mongosql-rs/schema-builder-library/pkg/schema-builder-library-nodejs.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/${build_variant}/schema-builder-library-nodejs.tgz
         permissions: public-read
-        content_type: application/wasm
+        content_type: application/gzip
 
   # "libmongosqltranslate" is the name of the library we release for on-prem SQL.
   "compile libmongosqltranslate":

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -16,42 +16,42 @@ functions:
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm
-        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
+        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
-        content_type: application/wasm
-        display_name: schema_builder_library-v${release_version}.wasm
+        content_type: application/gzip
+        display_name: schema-builder-library-nodejs-v${release_version}.tgz
     # signature file
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm.sig
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema_builder_library.wasm.sig
-        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz.sig
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
-        display_name: schema_builder_library-v${release_version}.wasm.sig
+        display_name: schema-builder-library-nodejs-v${release_version}.tgz.sig
 
   "sign schema-builder-library":
     - *assume_role_cmd
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm
-        local_file: mongosql-rs/schema_builder_library.wasm
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
+        local_file: mongosql-rs/schema-builder-library-nodejs.tgz
     - command: shell.exec
       type: system
       retry_on_failure: true
@@ -74,7 +74,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema_builder_library.wasm.sig --detach-sign schema_builder_library.wasm"
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema-builder-library-nodejs.tgz.sig --detach-sign schema-builder-library-nodejs.tgz"
     - command: shell.exec
       type: system
       params:
@@ -90,12 +90,12 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --verify schema_builder_library.wasm.sig schema_builder_library.wasm"
+            /bin/bash -c "gpgloader && gpg --verify schema-builder-library-nodejs.tgz.sig schema-builder-library-nodejs.tgz"
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/schema_builder_library.wasm.sig
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema_builder_library.wasm.sig
+        local_file: mongosql-rs/schema-builder-library-nodejs.tgz.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
         permissions: public-read
         content_type: application/octet-stream
 
@@ -110,11 +110,11 @@ functions:
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/papertrail/schema_builder_library-v${release_version}.wasm
-        remote_file: schema-builder-library/schema_builder_library-v${release_version}.wasm
+        local_file: mongosql-rs/papertrail/schema-builder-library-nodejs-v${release_version}.tgz
+        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
-        content_type: application/wasm
+        content_type: application/gzip
     - command: papertrail.trace
       params:
         work_dir: mongosql-rs

--- a/evergreen/schema-builder-library.yml
+++ b/evergreen/schema-builder-library.yml
@@ -16,42 +16,42 @@ functions:
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz
-        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz
+        remote_file: schema-builder-library/schema-builder-library-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/gzip
-        display_name: schema-builder-library-nodejs-v${release_version}.tgz
+        display_name: schema-builder-library-v${release_version}.tgz
     # signature file
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz.sig
     - command: s3.put
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library-nodejs.tgz.sig
-        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz.sig
+        local_file: mongosql-rs/release/schema-builder-library/schema-builder-library.tgz.sig
+        remote_file: schema-builder-library/schema-builder-library-v${release_version}.tgz.sig
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/octet-stream
-        display_name: schema-builder-library-nodejs-v${release_version}.tgz.sig
+        display_name: schema-builder-library-v${release_version}.tgz.sig
 
   "sign schema-builder-library":
     - *assume_role_cmd
     - command: s3.get
       params:
         <<: *evg_bucket_config
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz
-        local_file: mongosql-rs/schema-builder-library-nodejs.tgz
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz
+        local_file: mongosql-rs/schema-builder-library.tgz
     - command: shell.exec
       type: system
       retry_on_failure: true
@@ -74,7 +74,7 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema-builder-library-nodejs.tgz.sig --detach-sign schema-builder-library-nodejs.tgz"
+            /bin/bash -c "gpgloader && gpg --yes -v --armor -o schema-builder-library.tgz.sig --detach-sign schema-builder-library.tgz"
     - command: shell.exec
       type: system
       params:
@@ -90,12 +90,12 @@ functions:
             --rm \
             -v $(pwd):$(pwd) -w $(pwd) \
             ${garasign_gpg_image} \
-            /bin/bash -c "gpgloader && gpg --verify schema-builder-library-nodejs.tgz.sig schema-builder-library-nodejs.tgz"
+            /bin/bash -c "gpgloader && gpg --verify schema-builder-library.tgz.sig schema-builder-library.tgz"
     - command: s3.put
       params:
         <<: *evg_bucket_config
-        local_file: mongosql-rs/schema-builder-library-nodejs.tgz.sig
-        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library-nodejs.tgz.sig
+        local_file: mongosql-rs/schema-builder-library.tgz.sig
+        remote_file: mongosql-rs/artifacts/${version_id}/schema-builder-library/schema-builder-library.tgz.sig
         permissions: public-read
         content_type: application/octet-stream
 
@@ -110,8 +110,8 @@ functions:
       params:
         aws_key: ${release_aws_key}
         aws_secret: ${release_aws_secret}
-        local_file: mongosql-rs/papertrail/schema-builder-library-nodejs-v${release_version}.tgz
-        remote_file: schema-builder-library/schema-builder-library-nodejs-v${release_version}.tgz
+        local_file: mongosql-rs/papertrail/schema-builder-library-v${release_version}.tgz
+        remote_file: schema-builder-library/schema-builder-library-v${release_version}.tgz
         bucket: translators-connectors-releases
         permissions: public-read
         content_type: application/gzip


### PR DESCRIPTION
When trying to hook up integration tests with the .wasm produced by cargo build --target wasm32-unknown-unknown, Nick discovered the raw wasm wasn't enough on its own. Unbeknownst to us, wasm-pack (and the underlying wasm-bindgen-cli) doesn't only produce scaffolding files and helpers to marshal values, run init(), and set up imports — it actually rewrites the .wasm binary itself. Specifically, wasm-bindgen-cli rewrites the wasm's import/export table to match the generated JS glue, and wasm-opt then post-optimizes the binary. Without those steps, the .wasm we were releasing was unloadable from Node.

After some discussion, using wasm-pack looks like the best path forward.

Pros:
- It's how the POC and our integration tests were actually built — we know it works for both Compass and the integration tests, so this matches what downstream users will consume.
- wasm-pack pack emits a single .tgz, so no folder of loose files at release time. Output filename: schema-builder-library-nodejs-vX.Y.Z.tgz (plus .tgz.sig).

Cons:
- wasm-pack is opinionated about the JS host platform — if we want a separate web build later, we'll need to emit a second artifact. Mitigation: this is functionally a one-liner; we run wasm-pack build twice with different --target flags and use the naming convention (-nodejs, -web) to differentiate. The current naming already accommodates this.

The signing and SSDLC steps are unchanged — we just sign the .tgz instead of the .wasm. Nick has pulled these changes into the testing branch to confirm they work downstream. So functionally the only user-visible change is the artifact format (.wasm → .tgz), and it should be substantially more usable for Node consumers.